### PR TITLE
Update settings.kubernetes CORE_URI

### DIFF
--- a/settings.kubernetes
+++ b/settings.kubernetes
@@ -1,6 +1,6 @@
 """User defined settings"""
 
-CORE_URI = "http://172.17.42.102:30080/"
+CORE_URI = "http://192.168.64.2:30080"
 # Almost all servers either run graphite locally or have a local graphite proxy
 GRAPHITE_URI = "http://graphite.default.svc.cluster.local"
 MONGO_URI = "mongodb.default.svc.cluster.local:27017"

--- a/src/mist/monitor/config.py
+++ b/src/mist/monitor/config.py
@@ -1,6 +1,7 @@
 """Parses user defined settings from settings.py in top level dir."""
 
 import logging
+import os
 
 log = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ GRAPHITE_URI = settings.get("GRAPHITE_URI", "http://localhost")
 MONGO_URI = settings.get("MONGO_URI", "localhost:27022")
 MEMCACHED_URI = settings.get("MEMCACHED_URI", ["localhost:11211"])
 
+AUTH_FILE_PATH = settings.get("AUTH_FILE_PATH", os.getcwd() + "/conf/collectd.passwd")
 
 # Verify core's SSL certificate when communicating via HTTPS
 # (used by mist.alert when notifying core about rule status)

--- a/src/mist/monitor/methods.py
+++ b/src/mist/monitor/methods.py
@@ -39,7 +39,7 @@ def update_collectd_conf():
 
     lines = ["%s: %s\n" % (machine.uuid, machine.collectd_password)
              for machine in get_all_machines()]
-    with open(os.getcwd() + "/conf/collectd.passwd", "w") as f:
+    with open(config.AUTH_FILE_PATH, "w") as f:
         if CAN_LOCK:
             fcntl.flock(f.fileno(), fcntl.LOCK_EX)
         f.writelines(lines)


### PR DESCRIPTION
This PR fixes:

- Default Vagrant single-node ip
- Makes collectd.passwd file path configurable (aka AUTH_FILE_PATH in settings.py) and NOT HARDCODED